### PR TITLE
Allow the reporter method used by reviewdog to be configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.10
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ v0.9.13
 RUN wget -O - -q https://git.io/misspell | sh -s -- -b /usr/local/bin/
 
+RUN apk --no-cache add git && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Optional. -locale flag of misspell. (US/UK)
 Optional. Report level for reviewdog [info,warning,error].
 It's same as `-level` flag of reviewdog.
 
+### `reporter`
+
+Optional. Reporter of reviewdog command [github-pr-check,github-pr-review].
+It's same as `-reporter` flag of reviewdog.
+
 ## Example usage
 
 ### [.github/workflows/reviewdog.yml](.github/workflows/reviewdog.yml)

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  reporter:
+    description: 'Reporter of reviewdog command [github-pr-check,github-pr-review].'
+    default: 'github-pr-check'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -18,6 +21,7 @@ runs:
     - ${{ inputs.github_token }}
     - ${{ inputs.locale }}
     - ${{ inputs.level }}
+    - ${{ inputs.reporter }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ cd "$GITHUB_WORKSPACE"
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 misspell -locale="${INPUT_LOCALE}" . \
-  | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter=github-pr-check -level="${INPUT_LEVEL}"
+  | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter=${INPUT_REPORTER} -level="${INPUT_LEVEL}"


### PR DESCRIPTION
Hey!

In this pull request, I allow the `reporter` used by reviewdog to be configured.