### PR TITLE
Allow passing of a `find` command to select files for checking

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   reporter:
     description: 'Reporter of reviewdog command [github-pr-check,github-pr-review].'
     default: 'github-pr-check'
+  find_command:
+    description: 'A `find` command used to select files for spell checking'
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -22,6 +25,7 @@ runs:
     - ${{ inputs.locale }}
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}
+    - $${ inputs.find_command }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,11 @@ cd "$GITHUB_WORKSPACE"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-misspell -locale="${INPUT_LOCALE}" . \
-  | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+if [ -z "$INPUT_FIND_COMMAND" ]; then
+  misspell -locale="${INPUT_LOCALE}" . \
+    | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+else
+  eval $INPUT_FIND_COMMAND \
+    | xargs misspell -locale="${INPUT_LOCALE}" \
+    | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+fi


### PR DESCRIPTION
Misspell doesn't include any file-based exclude patterns and its docs recommend using `find` and `xargs` to accomplish filtering. This adds a `find_command` option to the action that can be set to limit which files will be checked.