### PR TITLE
resolve the conflict of #5

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,9 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: misspell
-        uses: reviewdog/action-misspell@v1
+        uses: ./
         with:
           github_token: ${{ secrets.github_token }}
           locale: "US"
+          pattern: "*.md"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Optional. File patterns of target files. Same as `-name [pattern]` of `find` com
 ### `exclude`
 
 Optional. Exclude patterns of target files. Same as `-not -path [exclude]` of `find` command.
-e.g. `./git/*`
+e.g. `.git/*`
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ It's the same as the `-reporter` flag of reviewdog.
 
 Optional. Ignore (`-i`) a list of comma-separated words.  [`armor`] / [`armor,color`].
 
+### `path`
+
+Optional. Base directory to run misspell. Same as `[path]` of `find` command. Default: `.`
+
+### `pattern`
+
+Optional. File patterns of target files. Same as `-name [pattern]` of `find` command. Default: `*`
+
+### `exclude`
+
+Optional. Exclude patterns of target files. Same as `-not -path [exclude]` of `find` command.
+e.g. `./git/*`
+
 ## Example usage
 
 ### [.github/workflows/reviewdog.yml](.github/workflows/reviewdog.yml)

--- a/action.yml
+++ b/action.yml
@@ -29,13 +29,6 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.github_token }}
-    - ${{ inputs.locale }}
-    - ${{ inputs.level }}
-    - ${{ inputs.reporter }}
-    - $${ inputs.find_command }}
-    - ${{ inputs.ignore }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,17 @@ inputs:
   reporter:
     description: 'Reporter of reviewdog command [github-pr-check,github-pr-review].'
     default: 'github-pr-check'
-  find_command:
-    description: 'A `find` command used to select files for spell checking'
   ignore:
     description: 'Comma-separated words to ignore'
+    default: ''
+  path:
+    description: "Base directory to run misspell. Same as `[path]` of `find` command."
+    default: '.'
+  pattern:
+    description: "File patterns of target files. Same as `-name [pattern]` of `find` command."
+    default: '*'
+  exclude:
+    description: "Exclude patterns of target files. Same as `-not -path [exclude]` of `find` command."
     default: ''
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   reporter:
     description: 'Reporter of reviewdog command [github-pr-check,github-pr-review].'
     default: 'github-pr-check'
+  find_command:
+    description: 'A `find` command used to select files for spell checking'
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -22,6 +25,7 @@ runs:
     - ${{ inputs.locale }}
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}
+    - $${ inputs.find_command }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,11 @@ cd "$GITHUB_WORKSPACE"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-misspell -locale="${INPUT_LOCALE}" . \
-  | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+if [ -z "$INPUT_FIND_COMMAND" ]; then
+  misspell -locale="${INPUT_LOCALE}" . \
+    | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+else
+  eval $INPUT_FIND_COMMAND \
+    | xargs misspell -locale="${INPUT_LOCALE}" \
+    | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,6 @@ cd "$GITHUB_WORKSPACE" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-if [ -z "$INPUT_FIND_COMMAND" ]; then
-  misspell -locale="${INPUT_LOCALE}" -i "${INPUT_IGNORE}" . \
+find "${INPUT_PATH:-'.'}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN:-'*'}" -print0 \
+    | xargs -0 misspell -locale="${INPUT_LOCALE}" -i "${INPUT_IGNORE}" \
     | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
-else
-  eval $INPUT_FIND_COMMAND \
-    | xargs misspell -locale="${INPUT_LOCALE}" -i "${INPUT_IGNORE}" \
-    | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
-fi


### PR DESCRIPTION
> Allow passing of a `find` command to select files for checking #5
> Misspell doesn't include any file-based exclude patterns and its docs recommend using `find` and `xargs` to accomplish filtering. This adds a `find_command` option to the action that can be set to limit which files will be checked.