### PR TITLE
add fail_on_error input

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ e.g. `.git/*`
 
 Optional. Filtering mode for the reviewdog command `[added,diff_context,file,nofilter]`. Default: `added`.
 
+### `fail_on_error`
+
+Optional. Exit code for reviewdog when errors are found [true,false]. Default: `false`.
+
 ## Example usage
 
 ### [.github/workflows/reviewdog.yml](.github/workflows/reviewdog.yml)

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   filter_mode:
     description: "Filtering mode for the reviewdog command [added,diff_context,file,nofilter]."
     default: 'added'
+  fail_on_error:
+    description: "Exit code for reviewdog when errors are found [true,false]."
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,12 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 find "${INPUT_PATH:-'.'}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN:-'*'}" -print0 \
     | xargs -0 misspell -locale="${INPUT_LOCALE}" -i "${INPUT_IGNORE}" \
-    | reviewdog -efm="%f:%l:%c: %m" -filter-mode="${INPUT_FILTER_MODE:-added}" -name="misspell" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+    | reviewdog -efm="%f:%l:%c: %m" \
+        -filter-mode="${INPUT_FILTER_MODE:-added}" \
+        -name="misspell" \
+        -reporter="${INPUT_REPORTER:-github-pr-check}" \
+        -level="${INPUT_LEVEL}" \
+        -fail-on-error="${INPUT_FAIL_ON_ERROR}"
+exit_code=$?
+
+exit $exit_code


### PR DESCRIPTION
I added it because there was no `fail_on_error` input.
https://github.com/reviewdog/reviewdog#exit-codes

about `exit $exit_code`
https://github.com/reviewdog/reviewdog/issues/949

test on my branch
https://github.com/Doarakko/reviewdog-playground/pull/14