### PR TITLE
Fix git error introduced in git 2.35.2

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd "${GITHUB_WORKSPACE}" || exit 1
 
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 paths=()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 cd "${GITHUB_WORKSPACE}" || exit 1
 
-git config --global --add safe.directory $GITHUB_WORKSPACE
+git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 


### PR DESCRIPTION
Git v2.35.2 spec changes are causing this action to error during run.

Related issues;

- https://github.com/reviewdog/action-misspell/issues/43
- https://github.com/reviewdog/action-misspell/issues/42
- https://github.com/reviewdog/reviewdog/issues/1158#issue-1202862728
- https://github.com/reviewdog/action-yamllint/issues/18

This PR follows the same process to fix the issue as the PR fix in action-yamllint.