### PR TITLE
Specify the direct URL because git.io redirecting will stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.15
 ENV REVIEWDOG_VERSION=v0.14.1
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
-RUN wget -O - -q https://git.io/misspell | sh -s -- -b /usr/local/bin/
+RUN wget -O - -q https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | sh -s -- -b /usr/local/bin/
 
 RUN apk --no-cache add git && \
     apk --no-cache add bash && \


### PR DESCRIPTION
GitHub announced below

https://github.blog/changelog/2022-04-25-git-io-deprecation/

> Effective Friday, April 29, 2022 all links on git.io will stop redirecting. Please update any existing links that make use of the git.io URL service immediately.

---

The process downloading install script will be affected.
This PR specify direct URL instead of shorten one.