### PR TITLE
change base image to debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM alpine:3.19
+FROM debian:bullseye-slim
 
 ENV REVIEWDOG_VERSION=v0.17.1
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 RUN wget -O - -q https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | sh -s -- -b /usr/local/bin/
-
-RUN apk --no-cache add git && \
-    apk --no-cache add bash && \
-    rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
When building on a rootless docker self-hosted runner, reviewdog installation fails with wget: bad address 'github.com'.
This seems to be an issue with alpine image and appears after 3.13.
I think the minimum fix is to downgrade to alpine 3.12 or use a different OS image.

https://github.com/alpinelinux/docker-alpine/issues/155

Same as https://github.com/reviewdog/action-markdownlint/pull/51
