### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,15 @@ exclude: |
 
 Optional. Filtering mode for the reviewdog command [`added`,`diff_context`,`file`,`nofilter`]. Default: `added`.
 
+### `fail_level`
+
+Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 Optional. Exit code for reviewdog when errors are found [`true`,`false`]. Default: `false`.
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Optional. Filtering mode for the reviewdog command [`added`,`diff_context`,`file
 
 ### `fail_level`
 
-Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Optional. If set to `none`, always use exit code 0 for reviewdog.
+Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
 Possible values: [`none`, `any`, `info`, `warning`, `error`]
 Default is `none`.
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,15 @@ inputs:
   filter_mode:
     description: "Filtering mode for the reviewdog command [added,diff_context,file,nofilter]."
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
-    description: "Exit code for reviewdog when errors are found [true,false]."
+    description: "Deprecated, use `fail_level` instead. Exit code for reviewdog when errors are found [true,false]."
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,7 @@ find "${paths[@]}" "${excludes[@]}" -type f "${names[@]}" -print0 \
         -name="misspell" \
         -reporter="${INPUT_REPORTER:-github-pr-check}" \
         -level="${INPUT_LEVEL}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 exit_code=$?
 


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.