### PR TITLE
chore: Bump reviewdog version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ENV REVIEWDOG_VERSION=v0.20.3
+ENV REVIEWDOG_VERSION=v0.21.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
We're hitting the error fixed by https://github.com/reviewdog/reviewdog/pull/2131

That fix is not in v0.20.3, but it is in v0.21.0.

CC @wlynch